### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ruby:2.3.0
 
+# Define locale
+ENV LANG C.UTF-8
+
 # Configure bundler
 RUN \
   bundle config --global frozen 1 && \


### PR DESCRIPTION
https://oncletom.io/2015/docker-encoding/

tl;dr: on blade (ubuntu) the default encoding was UTF-8. Here (coreos) doesnt set the locale. This fixes the issue
